### PR TITLE
Fix audio: modernize WebRTC APIs

### DIFF
--- a/Scripts/video.js
+++ b/Scripts/video.js
@@ -14,10 +14,8 @@
     var connection;
     
     var sdpConstraints = {
-        'mandatory': {
-            'OfferToReceiveAudio': true,
-            'OfferToReceiveVideo': true
-        }
+        offerToReceiveAudio: true,
+        offerToReceiveVideo: true
     };
 
     $localVideo.on('loadedmetadata', function () {
@@ -129,12 +127,13 @@
 
                 hub.invoke("IceCandidate", JSON.stringify({ "candidate": e.candidate }));
             };
-            connection.onaddstream = function (e) {
-                // Call the polyfill wrapper to attach the media stream to this element.
+            connection.ontrack = function (e) {
                 $callButton.prop('disabled', true);
                 $device.hide();
-                attachMediaStream(remoteVideo, e.stream);
-                trace('received remote stream');
+                if (remoteVideo.srcObject !== e.streams[0]) {
+                    remoteVideo.srcObject = e.streams[0];
+                    trace('received remote stream');
+                }
             };
             $call.show();
         }
@@ -169,29 +168,29 @@ function call() {
   } 
 
   if (localStream != null) {
-      connection.addStream(localStream);
+      localStream.getTracks().forEach(track => connection.addTrack(track, localStream));
       trace('Added local stream to connection');
   }
 
   trace('connection createOffer start');
-  connection.createOffer(onCreateOfferSuccess, errorHandler, sdpConstraints);
+  connection.createOffer(sdpConstraints).then(onCreateOfferSuccess).catch(errorHandler);
 }
 
 function answer(message) {    
     $remoteVideo.show();    
     $hangupButton.prop('disabled', false);
     trace('send answer ' + message.sdp);
-    connection.setRemoteDescription(new RTCSessionDescription(message.sdp), function () {       
+    connection.setRemoteDescription(new RTCSessionDescription(message.sdp)).then(function () {       
         trace('setRemoteDescription');
         if (localStream != null) {
-            connection.addStream(localStream);
+            localStream.getTracks().forEach(track => connection.addTrack(track, localStream));
         }
-            connection.createAnswer(function (desc) {
-                connection.setLocalDescription(desc, function () {
+            connection.createAnswer().then(function (desc) {
+                connection.setLocalDescription(desc).then(function () {
                     hub.invoke("Answer", JSON.stringify({ "sdp": desc }));
-                }, errorHandler);                
-            }, errorHandler);            
-    }, errorHandler);    
+                }).catch(errorHandler);
+            }).catch(errorHandler);
+    }).catch(errorHandler);    
 }
 
 function addIceCandidate(message) {
@@ -236,10 +235,10 @@ function onCreateOfferSuccess(desc) {
         hangup();
         return;
     }
-  connection.setLocalDescription(desc, function () {
+  connection.setLocalDescription(desc).then(function () {
       hub.invoke("Offer", conn, JSON.stringify({ "sdp": desc }));
-    onSetLocalSuccess(connection);
-  }, errorHandler);  
+      onSetLocalSuccess(connection);
+  }).catch(errorHandler);  
 }
 
 function onSetLocalSuccess(connection) {

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.7/signalr.min.js"></script>
 
         <!--<script src="//cdn.rawgit.com/webrtc/adapter/master/adapter.js"></script>-->
-        <script src="//cdnjs.cloudflare.com/ajax/libs/adapterjs/0.13.3/adapter.min.js"></script>
+        <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
         <!--<script src="//ajax.aspnetcdn.com/ajax/modernizr/modernizr-2.8.3.js"></script>-->
         <!--<script src="Scripts/bootstrap.min.js"></script>-->
         <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js" integrity="sha256-Sk3nkD6mLTMOF0EOpNtsIry+s1CsaqQC1rVLTAy+0yc= sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Problem
Video was working but audio was silent.

## Root Cause
The code used deprecated WebRTC APIs that modern browsers (Chrome/Edge 2024+) handle inconsistently:
- \connection.onaddstream\ (deprecated/removed)
- \connection.addStream()\ (deprecated)  
- Callback-based \createOffer\/\createAnswer\/\setLocalDescription\
- Old \dapterjs\ 0.13.3 (Temasys, 2017)

## Fixes
- \onaddstream\ → \ontrack\ (modern event, fires per-track including audio)
- \ddStream()\ → \ddTrack()\ per track
- All Promise-based WebRTC API calls
- Updated \sdpConstraints\ to modern flat format
- Replaced \dapterjs\ 0.13.3 with official \webrtc-adapter\ latest