### PR TITLE
Fix: define trace() helper removed from new webrtc-adapter

### DIFF
--- a/Scripts/utils.js
+++ b/Scripts/utils.js
@@ -1,3 +1,5 @@
+function trace(msg) { console.log(msg); }
+
 var ua = navigator.userAgent.toLowerCase();
 var isAndroid = ua.indexOf("android") > -1;
 console.log(ua);


### PR DESCRIPTION
trace() was a global exposed by old adapterjs. New webrtc-adapter does not include it. Added a simple wrapper in utils.js.