### PR TITLE
Fix autoplay policy blocks

### DIFF
--- a/Scripts/signalr.js
+++ b/Scripts/signalr.js
@@ -41,7 +41,7 @@ function userConnect(name) {
         $discussion.prepend('<li><strong>' + encodedName + '</strong>:&nbsp;&nbsp;' + message + '</li>');
         console.log('message', message);
         var audio = new Audio('/sound/page-flip-01a.mp3');
-        audio.play();
+        audio.play().catch(err => { if (err.name !== 'NotAllowedError') console.error('audio play failed:', err); });
     });
 
     hub.on("showUsersOnLine", function (users) {
@@ -50,7 +50,7 @@ function userConnect(name) {
         var usersdata = usersdata1.filter(function (el) { return el.name != $displayname.val(); });
         if (usersdata[0] != null) {
             var audio = new Audio('/sound/bottle-open-1.mp3');
-            audio.play().catch(() => {});
+            audio.play().catch(err => { if (err.name !== 'NotAllowedError') console.error('audio play failed:', err); });
             $users.empty();
             $users.append('<input type="radio" value="public" name="user" checked><label>Public</label><br />');
             for (var i = 0; i < usersdata.length; i++) {

--- a/Scripts/signalr.js
+++ b/Scripts/signalr.js
@@ -50,7 +50,7 @@ function userConnect(name) {
         var usersdata = usersdata1.filter(function (el) { return el.name != $displayname.val(); });
         if (usersdata[0] != null) {
             var audio = new Audio('/sound/bottle-open-1.mp3');
-            audio.play();
+            audio.play().catch(() => {});
             $users.empty();
             $users.append('<input type="radio" value="public" name="user" checked><label>Public</label><br />');
             for (var i = 0; i < usersdata.length; i++) {

--- a/Scripts/video.js
+++ b/Scripts/video.js
@@ -132,6 +132,7 @@
                 $device.hide();
                 if (remoteVideo.srcObject !== e.streams[0]) {
                     remoteVideo.srcObject = e.streams[0];
+                    remoteVideo.play().catch(err => trace('remoteVideo play failed: ' + err));
                     trace('received remote stream');
                 }
             };


### PR DESCRIPTION
- Catch audio.play() rejection for notification sound (fires before user interaction)
- Add explicit remoteVideo.play().catch() in ontrack for the remote video stream