### PR TITLE
Fix audio: show click-to-enable button when autoplay blocked

### DIFF
--- a/Scripts/video.js
+++ b/Scripts/video.js
@@ -132,7 +132,12 @@
                 $device.hide();
                 if (remoteVideo.srcObject !== e.streams[0]) {
                     remoteVideo.srcObject = e.streams[0];
-                    remoteVideo.play().catch(err => trace('remoteVideo play failed: ' + err));
+                    remoteVideo.play().catch(err => {
+                        trace('remoteVideo play failed: ' + err);
+                        if (err.name === 'NotAllowedError') {
+                            document.getElementById('enableAudioBtn').style.display = 'block';
+                        }
+                    });
                     trace('received remote stream');
                 }
             };
@@ -296,6 +301,7 @@ function hangup() {
   connection.close();  
   connection = null;    
   $remoteVideo.hide();
+  document.getElementById('enableAudioBtn').style.display = 'none';
   $device.show();   
   connect();  
   $hangupButton.prop('disabled', true);  

--- a/index.html
+++ b/index.html
@@ -41,7 +41,13 @@
 
 
         <div id="video" class="panel panel-default" hidden>
-            <video id="remoteVideo" autoplay width="640" height="480" controls></video>
+            <div style="position:relative;display:inline-block;">
+                <video id="remoteVideo" autoplay width="640" height="480" controls></video>
+                <button id="enableAudioBtn" onclick="document.getElementById('remoteVideo').play();this.style.display='none';"
+                    style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:1.2em;padding:10px 20px;cursor:pointer;">
+                    🔊 Click to enable audio
+                </button>
+            </div>
             <video id="localVideo" autoplay muted title="Local video" width="320" height="240"></video>
         </div>
         <br />


### PR DESCRIPTION
The **answerer** receives calls automatically via SignalR with no user gesture, so the browser blocks \emoteVideo.play()\ with audio (NotAllowedError). Added an overlay button over the remote video that appears only when needed — clicking it triggers \.play()\ from a user gesture, which the browser allows.