### PR TITLE
Fix mobile layout stacking

### DIFF
--- a/signalrtc.css
+++ b/signalrtc.css
@@ -493,6 +493,10 @@ a {
         flex-direction: column;
     }
 
+    .app-grid {
+        display: block;
+    }
+
     .video-stage {
         grid-template-columns: 1fr;
     }

--- a/signalrtc.css
+++ b/signalrtc.css
@@ -55,8 +55,17 @@ a {
     font-weight: 700;
 }
 
+.app-hero__content {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.app-hero__status {
+    flex: 0 0 auto;
+}
+
 .app-subtitle {
-    max-width: 720px;
+    max-width: 100%;
     margin: 0;
     font-size: 16px;
     line-height: 1.6;


### PR DESCRIPTION
Mobile layout: under 992px, disable the flex layout on .app-grid so Bootstrap columns stack full-width. This prevents the roster/device column and chat/video column from squeezing side-by-side on phones.